### PR TITLE
Dialog before deleting double unique name object

### DIFF
--- a/Source/Core/Runtime/Configuration/RuntimeConfigurator.cs
+++ b/Source/Core/Runtime/Configuration/RuntimeConfigurator.cs
@@ -131,7 +131,6 @@ namespace VRBuilder.Core.Configuration
 
                 Instance.runtimeConfigurationName = value.GetType().AssemblyQualifiedName;
                 Instance.runtimeConfiguration = value;
-                Configuration.SceneObjectRegistry.RegisterAll();
 
                 EmitRuntimeConfigurationChanged();
             }

--- a/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
@@ -50,7 +50,7 @@ namespace VRBuilder.Core.SceneObjects
                         Object.DestroyImmediate(trainingObject.gameObject);
                     }
 #else
-                    Debug.LogErrorFormat("Registration of training scene object entity with name '{0}' failed. Name is not unique! Entity will destroy itself. Referenced game object: '{1}'.", trainingObject.UniqueName, trainingObject.GameObject.name);
+                    Debug.LogErrorFormat("Registration of training scene object entity with name '{0}' failed. Name is not unique! Errors will ensue. Referenced game object: '{1}'.", trainingObject.UniqueName, trainingObject.GameObject.name);
 #endif
                 }
                 catch (AlreadyRegisteredException)

--- a/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
@@ -9,6 +9,7 @@ using VRBuilder.Core.Exceptions;
 using VRBuilder.Unity;
 using UnityEngine;
 using Object = UnityEngine.Object;
+using UnityEditor;
 
 namespace VRBuilder.Core.SceneObjects
 {
@@ -42,8 +43,14 @@ namespace VRBuilder.Core.SceneObjects
                 }
                 catch (NameNotUniqueException)
                 {
-                    Debug.LogErrorFormat("Registration of training scene object entity with name '{0}' failed. Name is not unique! Entity will destroy itself. Referenced game object: '{1}'.", trainingObject.UniqueName, trainingObject.GameObject.name);
-                    Object.DestroyImmediate(trainingObject.gameObject);
+#if UNITY_EDITOR
+                    if (EditorUtility.DisplayDialog("Scene Object Name Conflict", $"The game object {trainingObject.gameObject.name} cannot be registered because it has an already existing unique name: {trainingObject.UniqueName}. Do you want to delete it?", "Yes", "No"))
+                    {
+                        Object.DestroyImmediate(trainingObject.gameObject);
+                    }
+#else
+                   Debug.LogErrorFormat("Registration of training scene object entity with name '{0}' failed. Name is not unique! Entity will destroy itself. Referenced game object: '{1}'.", trainingObject.UniqueName, trainingObject.GameObject.name);
+#endif
                 }
                 catch (AlreadyRegisteredException)
                 {

--- a/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
@@ -49,7 +49,7 @@ namespace VRBuilder.Core.SceneObjects
                         Object.DestroyImmediate(trainingObject.gameObject);
                     }
 #else
-                   Debug.LogErrorFormat("Registration of training scene object entity with name '{0}' failed. Name is not unique! Entity will destroy itself. Referenced game object: '{1}'.", trainingObject.UniqueName, trainingObject.GameObject.name);
+                    Debug.LogErrorFormat("Registration of training scene object entity with name '{0}' failed. Name is not unique! Entity will destroy itself. Referenced game object: '{1}'.", trainingObject.UniqueName, trainingObject.GameObject.name);
 #endif
                 }
                 catch (AlreadyRegisteredException)

--- a/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectRegistry.cs
@@ -44,7 +44,8 @@ namespace VRBuilder.Core.SceneObjects
                 catch (NameNotUniqueException)
                 {
 #if UNITY_EDITOR
-                    if (EditorUtility.DisplayDialog("Scene Object Name Conflict", $"The game object {trainingObject.gameObject.name} cannot be registered because it has an already existing unique name: {trainingObject.UniqueName}. Do you want to delete it?", "Yes", "No"))
+                    string isPlayingText = Application.isPlaying ? "\n\nThe object will be restored after ending Play Mode." : "\n\nThe object will be deleted from the scene.";
+                    if (EditorUtility.DisplayDialog("Scene Object Name Conflict", $"The game object {trainingObject.gameObject.name} cannot be registered because it has an already existing unique name: {trainingObject.UniqueName}. Do you want to delete it?{isPlayingText}", "Yes", "No"))
                     {
                         Object.DestroyImmediate(trainingObject.gameObject);
                     }


### PR DESCRIPTION
When registering all TSOs, if an existing name exception is thrown a dialog will appear asking the user if they want to delete the gameobject instead of deleting it outright.