### PR TITLE
Open context menu after dragging from step

### DIFF
--- a/Source/Core/Editor/UI/Windows/ChapterRepresentation.cs
+++ b/Source/Core/Editor/UI/Windows/ChapterRepresentation.cs
@@ -504,47 +504,7 @@ namespace VRBuilder.Editor.UI.Windows
                 IStep step = EntityFactory.CreateStep("New Step");
                 step.StepMetadata.Position = pointerPosition;
                 AddStepWithUndo(step);
-
-                if (joint != null)
-                {
-                    if (joint.Parent is EntryNode)
-                    {
-                        IStep oldStep = CurrentChapter.Data.FirstStep;
-
-                        RevertableChangesHandler.Do(new CourseCommand(() =>
-                        {
-                            CurrentChapter.Data.FirstStep = step;
-                            MarkToRefresh();
-                        },
-                        () =>
-                        {
-                            CurrentChapter.Data.FirstStep = oldStep;
-                            MarkToRefresh();
-                        }
-                        ));
-                    }
-                    else if (joint.Parent is StepNode)
-                    {                        
-                        StepNode stepNode = joint.Parent as StepNode;
-                        int index = stepNode.ExitJoints.IndexOf(joint);
-                        ITransition transition = stepNode.Step.Data.Transitions.Data.Transitions[index];
-                        IStep oldStep = transition.Data.TargetStep;
-
-                        RevertableChangesHandler.Do(new CourseCommand(() =>
-                        {
-                            transition.Data.TargetStep = step;
-                            SelectStepNode(stepNode);
-                            MarkToRefresh();
-                        },
-                        () =>
-                        {
-                            transition.Data.TargetStep = oldStep;
-                            SelectStepNode(stepNode);
-                            MarkToRefresh();
-                        }
-                    ));
-                    }
-                }
+                HandleTransition(joint, step);
             }));
 
             if (SystemClipboard.IsStepInClipboard())
@@ -560,7 +520,51 @@ namespace VRBuilder.Editor.UI.Windows
             }
 
             TestableEditorElements.DisplayContextMenu(options);
-        }       
+        }
+
+        private void HandleTransition(ExitJoint exitJoint, IStep targetStep)
+        {
+            if (exitJoint != null)
+            {
+                if (exitJoint.Parent is EntryNode)
+                {
+                    IStep oldStep = CurrentChapter.Data.FirstStep;
+
+                    RevertableChangesHandler.Do(new CourseCommand(() =>
+                    {
+                        CurrentChapter.Data.FirstStep = targetStep;
+                        MarkToRefresh();
+                    },
+                    () =>
+                    {
+                        CurrentChapter.Data.FirstStep = oldStep;
+                        MarkToRefresh();
+                    }
+                    ));
+                }
+                else if (exitJoint.Parent is StepNode)
+                {
+                    StepNode stepNode = exitJoint.Parent as StepNode;
+                    int index = stepNode.ExitJoints.IndexOf(exitJoint);
+                    ITransition transition = stepNode.Step.Data.Transitions.Data.Transitions[index];
+                    IStep oldStep = transition.Data.TargetStep;
+
+                    RevertableChangesHandler.Do(new CourseCommand(() =>
+                    {
+                        transition.Data.TargetStep = targetStep;
+                        SelectStepNode(stepNode);
+                        MarkToRefresh();
+                    },
+                    () =>
+                    {
+                        transition.Data.TargetStep = oldStep;
+                        SelectStepNode(stepNode);
+                        MarkToRefresh();
+                    }
+                ));
+                }
+            }
+        }
 
         public void SetChapter(IChapter chapter)
         {

--- a/Source/Core/Editor/UI/Windows/ChapterRepresentation.cs
+++ b/Source/Core/Editor/UI/Windows/ChapterRepresentation.cs
@@ -308,7 +308,7 @@ namespace VRBuilder.Editor.UI.Windows
 
                 if (TryGetStepForTransitionDrag(args.PointerPosition, out IStep target) == false)
                 {
-                    HandleCanvasContextClick(sender, args);
+                    DisplayContextMenu(args.PointerPosition);
                     return;
                 }
 
@@ -366,7 +366,7 @@ namespace VRBuilder.Editor.UI.Windows
 
                         if (TryGetStepForTransitionDrag(args.PointerPosition, out IStep targetStep) == false)
                         {
-                            HandleCanvasContextClick(sender, args);
+                            DisplayContextMenu(args.PointerPosition);
                             return;
                         }
 
@@ -492,20 +492,25 @@ namespace VRBuilder.Editor.UI.Windows
 
         private void HandleCanvasContextClick(object sender, PointerGraphicalElementEventArgs e)
         {
+            DisplayContextMenu(e.PointerPosition);
+        }
+
+        private void DisplayContextMenu(Vector2 pointerPosition)
+        {
             IList<TestableEditorElements.MenuOption> options = new List<TestableEditorElements.MenuOption>();
 
             options.Add(new TestableEditorElements.MenuItem(new GUIContent("Add step"), false, () =>
             {
                 IStep step = EntityFactory.CreateStep("New Step");
-                step.StepMetadata.Position = e.PointerPosition;
-                AddStepWithUndo(step);
+                step.StepMetadata.Position = pointerPosition;
+                AddStepWithUndo(step);                
             }));
 
             if (SystemClipboard.IsStepInClipboard())
             {
                 options.Add(new TestableEditorElements.MenuItem(new GUIContent("Paste step"), false, () =>
                 {
-                    Paste(e.PointerPosition);
+                    Paste(pointerPosition);
                 }));
             }
             else

--- a/Source/Core/Editor/UI/Windows/ChapterRepresentation.cs
+++ b/Source/Core/Editor/UI/Windows/ChapterRepresentation.cs
@@ -511,7 +511,7 @@ namespace VRBuilder.Editor.UI.Windows
             {
                 options.Add(new TestableEditorElements.MenuItem(new GUIContent("Paste step"), false, () =>
                 {
-                    Paste(pointerPosition);
+                    Paste(pointerPosition, joint);
                 }));
             }
             else
@@ -659,7 +659,7 @@ namespace VRBuilder.Editor.UI.Windows
         /// Pastes the step from the system's copy buffer into the chapter at given <paramref name="position"/>.
         /// </summary>
         /// <returns>True if successful.</returns>
-        public bool Paste(Vector2 position)
+        public bool Paste(Vector2 position, ExitJoint connection = null)
         {
             IStep step;
             try
@@ -681,6 +681,10 @@ namespace VRBuilder.Editor.UI.Windows
             }
 
             AddStepWithUndo(step);
+            if(connection != null)
+            {
+                HandleTransition(connection, step);
+            }
 
             return true;
         }

--- a/Source/Core/Editor/UI/Windows/ChapterRepresentation.cs
+++ b/Source/Core/Editor/UI/Windows/ChapterRepresentation.cs
@@ -308,6 +308,7 @@ namespace VRBuilder.Editor.UI.Windows
 
                 if (TryGetStepForTransitionDrag(args.PointerPosition, out IStep target) == false)
                 {
+                    HandleCanvasContextClick(sender, args);
                     return;
                 }
 
@@ -365,6 +366,7 @@ namespace VRBuilder.Editor.UI.Windows
 
                         if (TryGetStepForTransitionDrag(args.PointerPosition, out IStep targetStep) == false)
                         {
+                            HandleCanvasContextClick(sender, args);
                             return;
                         }
 
@@ -440,7 +442,7 @@ namespace VRBuilder.Editor.UI.Windows
             }
             else
             {
-                return elementUnderCursor == null;
+                return elementUnderCursor != null;
             }
         }
 


### PR DESCRIPTION
Dragging from a step exit point and releasing in an empty area opens the context menu, allowing to create or paste a new step connected to the previous one.