### PR TITLE
Fix for compile errors if input system already set to new

### DIFF
--- a/Source/Core/Editor/Input/InputEditorUtils.cs
+++ b/Source/Core/Editor/Input/InputEditorUtils.cs
@@ -13,7 +13,7 @@ namespace VRBuilder.Editor.Input
     /// </summary>
     public static class InputEditorUtils
     {
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && INPUT_SYSTEM_PACKAGE
         /// <summary>
         /// Copies the custom key bindings into the project by using the default one.
         /// </summary>

--- a/Source/Core/Editor/VRBuilder.Editor.asmdef
+++ b/Source/Core/Editor/VRBuilder.Editor.asmdef
@@ -39,6 +39,11 @@
             "name": "com.unity.xr.openxr",
             "expression": "",
             "define": "OPEN_XR"
+        },
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "1.0.1",
+            "define": "INPUT_SYSTEM_PACKAGE"
         }
     ],
     "noEngineReferences": false

--- a/Source/Core/Runtime/Configuration/BaseRuntimeConfiguration.cs
+++ b/Source/Core/Runtime/Configuration/BaseRuntimeConfiguration.cs
@@ -50,7 +50,7 @@ namespace VRBuilder.Core.Configuration
         /// </summary>
         public virtual string CustomInputActionAssetPath { get; } = "KeyBindings/BuilderCustomKeyBindings";
 
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && INPUT_SYSTEM_PACKAGE
         private UnityEngine.InputSystem.InputActionAsset inputActionAsset;
 
         /// <summary>

--- a/Source/Core/Runtime/Input/DefaultInputController.cs
+++ b/Source/Core/Runtime/Input/DefaultInputController.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2013-2019 Innoactive GmbH
+// Copyright (c) 2013-2019 Innoactive GmbH
 // Licensed under the Apache License, Version 2.0
 // Modifications copyright (c) 2021 MindPort GmbH
 
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && INPUT_SYSTEM_PACKAGE
 
 using System;
 using System.Collections.Generic;

--- a/Source/Core/Runtime/VRBuilder.Core.asmdef
+++ b/Source/Core/Runtime/VRBuilder.Core.asmdef
@@ -13,6 +13,12 @@
     ],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "1.0.1",
+            "define": "INPUT_SYSTEM_PACKAGE"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Added check if Input System package is present to prevent attempting to compile related code when new input system is enabled but the package is not installed.