### PR TITLE
Set parent behavior

### DIFF
--- a/Source/Basic-Conditions-And-Behaviors/Editor/UI/MenuItems/SetParentMenuItem.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Editor/UI/MenuItems/SetParentMenuItem.cs
@@ -1,0 +1,18 @@
+using VRBuilder.Core.Behaviors;
+using VRBuilder.Editor.UI.StepInspector.Menu;
+
+namespace VRBuilder.Editor.UI.Conditions
+{
+    /// <inheritdoc />
+    public class SetParentMenuItem : MenuItem<IBehavior>
+    {
+        /// <inheritdoc />
+        public override string DisplayedName { get; } = "Utility/Set Parent";
+
+        /// <inheritdoc />
+        public override IBehavior GetNewItem()
+        {
+            return new SetParentBehavior();
+        }
+    }
+}

--- a/Source/Basic-Conditions-And-Behaviors/Editor/UI/MenuItems/SetParentMenuItem.cs.meta
+++ b/Source/Basic-Conditions-And-Behaviors/Editor/UI/MenuItems/SetParentMenuItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d47d0237421b69a439d7af2598b17866
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs
@@ -8,7 +8,9 @@ using VRBuilder.Core.Utils;
 
 namespace VRBuilder.Core.Behaviors
 {
-    // This behavior changes the parent of a game object in the scene hierarchy.
+    /// <summary>
+    /// This behavior changes the parent of a game object in the scene hierarchy. It can accept a null parent, in which case the object will be unparented.
+    /// </summary>
     [DataContract(IsReference = true)]
     public class SetParentBehavior : Behavior<SetParentBehavior.EntityData>
     {

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+using Newtonsoft.Json;
+using System.Collections;
+using System.Runtime.Serialization;
+using VRBuilder.Core.Attributes;
+using VRBuilder.Core.SceneObjects;
+
+namespace VRBuilder.Core.Behaviors
+{
+    // This behavior changes the parent of a game object in the scene hierarchy.
+    [DataContract(IsReference = true)]
+    public class SetParentBehavior : Behavior<SetParentBehavior.EntityData>
+    {
+        [DisplayName("Set Parent")]
+        [DataContract(IsReference = true)]
+        public class EntityData : IBehaviorData
+        {
+            // Process object to reparent.
+            [DataMember]
+            public SceneObjectReference Target { get; set; }
+
+            // New parent game object.
+            [DataMember]
+            public SceneObjectReference Parent { get; set; }
+
+            public Metadata Metadata { get; set; }
+            public string Name { get; set; }
+        }
+
+        // Handle data initialization in the constructor.
+        [JsonConstructor]
+        public SetParentBehavior() : this(new SceneObjectReference(), new SceneObjectReference())
+        {
+        }
+
+        public SetParentBehavior(SceneObjectReference target, SceneObjectReference parent)
+        {
+            Data.Target = target;
+            Data.Parent = parent;
+        }
+
+        private class ActivatingProcess : StageProcess<EntityData>
+        {
+            public ActivatingProcess(EntityData data) : base(data)
+            {
+            }
+
+            /// <inheritdoc />
+            public override void Start()
+            {
+            }
+
+            /// <inheritdoc />
+            public override IEnumerator Update()
+            {
+                yield return null;
+            }
+
+            /// <inheritdoc />
+            public override void End()
+            {
+                if (Data.Parent.Value == null)
+                {
+                    Data.Target.Value.GameObject.transform.SetParent(null);
+                }
+                else
+                {
+                    Data.Target.Value.GameObject.transform.SetParent(Data.Parent.Value.GameObject.transform);
+                }
+            }
+
+            /// <inheritdoc />
+            public override void FastForward()
+            {
+            }
+        }
+
+        /// <inheritdoc />
+        public override IStageProcess GetActivatingProcess()
+        {
+            return new ActivatingProcess(Data);
+        }
+    }
+}

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Runtime.Serialization;
 using VRBuilder.Core.Attributes;
 using VRBuilder.Core.SceneObjects;
+using VRBuilder.Core.Utils;
 
 namespace VRBuilder.Core.Behaviors
 {
@@ -33,14 +34,18 @@ namespace VRBuilder.Core.Behaviors
 
         // Handle data initialization in the constructor.
         [JsonConstructor]
-        public SetParentBehavior() : this(new SceneObjectReference(), new SceneObjectReference())
+        public SetParentBehavior() : this("", "")
         {
         }
 
-        public SetParentBehavior(SceneObjectReference target, SceneObjectReference parent, bool snapToParentTransform = false)
+        public SetParentBehavior(ISceneObject target, ISceneObject parent, bool snapToParentTransform = false) : this(ProcessReferenceUtils.GetNameFrom(target), ProcessReferenceUtils.GetNameFrom(parent), snapToParentTransform)
         {
-            Data.Target = target;
-            Data.Parent = parent;
+        }
+
+        public SetParentBehavior(string target, string parent, bool snapToParentTransform = false)
+        {
+            Data.Target = new SceneObjectReference(target);
+            Data.Parent = new SceneObjectReference(parent);
             Data.SnapToParentTransform = snapToParentTransform;
         }
 

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs
@@ -23,6 +23,10 @@ namespace VRBuilder.Core.Behaviors
             [DataMember]
             public SceneObjectReference Parent { get; set; }
 
+            [DataMember]
+            [DisplayName("Snap to parent transform")]
+            public bool SnapToParentTransform { get; set; }
+
             public Metadata Metadata { get; set; }
             public string Name { get; set; }
         }
@@ -33,10 +37,11 @@ namespace VRBuilder.Core.Behaviors
         {
         }
 
-        public SetParentBehavior(SceneObjectReference target, SceneObjectReference parent)
+        public SetParentBehavior(SceneObjectReference target, SceneObjectReference parent, bool snapToParentTransform = false)
         {
             Data.Target = target;
             Data.Parent = parent;
+            Data.SnapToParentTransform = snapToParentTransform;
         }
 
         private class ActivatingProcess : StageProcess<EntityData>
@@ -65,7 +70,13 @@ namespace VRBuilder.Core.Behaviors
                 }
                 else
                 {
-                    Data.Target.Value.GameObject.transform.SetParent(Data.Parent.Value.GameObject.transform);
+                    Data.Target.Value.GameObject.transform.SetParent(Data.Parent.Value.GameObject.transform, true);                   
+                    
+                    if(Data.SnapToParentTransform)
+                    {
+                        Data.Target.Value.GameObject.transform.localPosition = Vector3.zero;
+                        Data.Target.Value.GameObject.transform.localRotation = Quaternion.identity;
+                    }
                 }
             }
 

--- a/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs.meta
+++ b/Source/Basic-Conditions-And-Behaviors/Runtime/Behaviors/SetParentBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a3ec2ec04c7c644eb56b83ed793f969
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/BehaviorTests.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/BehaviorTests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine.TestTools;
+using VRBuilder.Core.Behaviors;
+using VRBuilder.Tests.Utils;
+
+namespace VRBuilder.Core.Tests.Behaviors
+{
+    public abstract class BehaviorTests : RuntimeTests
+    {
+        protected abstract IBehavior CreateDefaultBehavior();       
+
+        [UnityTest]
+        public IEnumerator FastForwardInactiveBehavior()
+        {
+            // Given a behavior,
+            IBehavior behavior = CreateDefaultBehavior();
+
+            // When we mark it to fast-forward,
+            behavior.LifeCycle.MarkToFastForward();
+
+            // Then it doesn't autocomplete because it hasn't been activated yet.
+            Assert.AreEqual(Stage.Inactive, behavior.LifeCycle.Stage);
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator FastForwardInactiveBehaviorAndActivateIt()
+        {
+            // Given a behavior,
+            IBehavior behavior = CreateDefaultBehavior();
+
+            // When we mark it to fast-forward and activate it,
+            behavior.LifeCycle.MarkToFastForward();
+            behavior.LifeCycle.Activate();
+
+            // Then the behavior should be activated immediately.
+            Assert.AreEqual(Stage.Active, behavior.LifeCycle.Stage);
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator FastForwardActivatingBehavior()
+        {
+            // Given a behavior,
+            IBehavior behavior = CreateDefaultBehavior();
+
+            behavior.LifeCycle.Activate();
+
+            // When we mark it to fast-forward,
+            behavior.LifeCycle.MarkToFastForward();
+
+            // Then the behavior should be activated immediately.
+            Assert.AreEqual(Stage.Active, behavior.LifeCycle.Stage);
+
+            yield break;
+        }
+    }
+}

--- a/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/BehaviorTests.cs.meta
+++ b/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/BehaviorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c259ad9c9943a024ab870b3917217572
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/SetParentBehaviorTests.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/SetParentBehaviorTests.cs
@@ -1,0 +1,122 @@
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.TestTools;
+using VRBuilder.Core.Behaviors;
+using VRBuilder.Core.SceneObjects;
+
+namespace VRBuilder.Core.Tests.Behaviors
+{
+    [TestFixture]    
+    public class SetParentBehaviorTests : BehaviorTests
+    {
+        List<GameObject> spawnedObjects = new List<GameObject>();
+
+        protected override IBehavior CreateDefaultBehavior()
+        {
+            ISceneObject target = SpawnTestObject("Target", Vector3.zero, Quaternion.identity, Vector3.one);
+            ISceneObject parent = SpawnTestObject("Parent", Vector3.zero, Quaternion.identity, Vector3.one);
+            return new SetParentBehavior(target, parent);
+        }
+
+        public ProcessSceneObject SpawnTestObject(string name, Vector3 position, Quaternion rotation, Vector3 scale, Transform parent = null)
+        {
+            GameObject spawnedObject = new GameObject(name);
+            spawnedObject.transform.SetPositionAndRotation(position, rotation);
+            spawnedObject.transform.localScale = scale;
+            spawnedObjects.Add(spawnedObject);            
+            return spawnedObject.AddComponent<ProcessSceneObject>();
+        }
+
+        private static TestCaseData[] snapTestCases = new TestCaseData[]
+        {
+            new TestCaseData(new Vector3(3, -2, 6), Quaternion.Euler(-5, 7, 43)).Returns(null),
+            new TestCaseData(new Vector3(75, 2, 8), Quaternion.Euler(123, 65, 41)).Returns(null),
+            new TestCaseData(new Vector3(0, 0, 0), Quaternion.Euler(45, 2, -12)).Returns(null),
+            new TestCaseData(new Vector3(5, -6, 2), Quaternion.Euler(0, 0, 0)).Returns(null),
+        };
+
+        [TearDown]
+        public void DeleteAllObjects()
+        {
+            foreach(GameObject spawnedObject in spawnedObjects)
+            {
+                GameObject.DestroyImmediate(spawnedObject);
+            }
+
+            spawnedObjects.Clear();
+        }
+
+        [UnityTest]
+        public IEnumerator ObjectIsParented()
+        {
+            // Given a set parent behavior,
+            ProcessSceneObject target = SpawnTestObject("Target", Vector3.zero, Quaternion.identity, Vector3.one);
+            ProcessSceneObject parent = SpawnTestObject("Parent", Vector3.zero, Quaternion.identity, Vector3.one);
+            IBehavior behavior = new SetParentBehavior(target, parent);
+
+            // When the behavior completes,
+            behavior.LifeCycle.Activate();
+
+            while(behavior.LifeCycle.Stage != Stage.Active)
+            {
+                yield return null;
+                behavior.Update();
+            }
+
+            // Then the target object has been parented.
+            Assert.AreEqual(parent.transform, target.transform.parent);
+        }
+
+        [UnityTest]        
+        [TestCaseSource(nameof(snapTestCases))]
+        public IEnumerator ObjectSnapsToParentIfSet(Vector3 parentPosition, Quaternion parentRotation)
+        {
+            // Given a set parent behavior,
+            ProcessSceneObject target = SpawnTestObject("Target", Vector3.zero, Quaternion.identity, Vector3.one);
+            ProcessSceneObject parent = SpawnTestObject("Parent", parentPosition, parentRotation, Vector3.one);
+            IBehavior behavior = new SetParentBehavior(target, parent, true);
+
+            // When the behavior completes,
+            behavior.LifeCycle.Activate();
+
+            while (behavior.LifeCycle.Stage != Stage.Active)
+            {
+                yield return null;
+                behavior.Update();
+            }
+
+            // Then the target object has been parented, and it snaps to the parent's position.
+            Assert.AreEqual(parent.transform, target.transform.parent);
+            Assert.IsTrue(parent.transform.position == target.transform.position);
+            Assert.IsTrue((parent.transform.rotation == target.transform.rotation));
+        }
+
+        [UnityTest]
+        [TestCaseSource(nameof(snapTestCases))]
+        public IEnumerator ObjectDoesNotSnapToParentIfNotSet(Vector3 parentPosition, Quaternion parentRotation)
+        {
+            // Given a set parent behavior,
+            Vector3 originalPosition = new Vector3(456, 42, - 22);
+            Quaternion originalRotation = Quaternion.Euler(34, -56, 190);
+            ProcessSceneObject target = SpawnTestObject("Target", originalPosition, originalRotation, Vector3.one);
+            ProcessSceneObject parent = SpawnTestObject("Parent", parentPosition, parentRotation, Vector3.one);
+            IBehavior behavior = new SetParentBehavior(target, parent, false);
+
+            // When the behavior completes,
+            behavior.LifeCycle.Activate();
+
+            while (behavior.LifeCycle.Stage != Stage.Active)
+            {
+                yield return null;
+                behavior.Update();
+            }
+
+            // Then the target object has been parented, and it snaps to the parent's position.
+            Assert.AreEqual(parent.transform, target.transform.parent);
+            Assert.IsTrue(originalPosition == target.transform.position);
+            Assert.IsTrue((originalRotation == target.transform.rotation));
+        }
+    }
+}

--- a/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/SetParentBehaviorTests.cs
+++ b/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/SetParentBehaviorTests.cs
@@ -88,9 +88,9 @@ namespace VRBuilder.Core.Tests.Behaviors
             }
 
             // Then the target object has been parented, and it snaps to the parent's position.
-            Assert.AreEqual(parent.transform, target.transform.parent);
-            Assert.IsTrue(parent.transform.position == target.transform.position);
-            Assert.IsTrue((parent.transform.rotation == target.transform.rotation));
+            Assert.AreEqual(parent.transform, target.transform.parent);            
+            Assert.IsTrue((parent.transform.position - target.transform.position).sqrMagnitude < 0.001f);
+            Assert.IsTrue(Quaternion.Dot(parent.transform.rotation, target.transform.rotation) > 0.999f);
         }
 
         [UnityTest]
@@ -113,10 +113,32 @@ namespace VRBuilder.Core.Tests.Behaviors
                 behavior.Update();
             }
 
-            // Then the target object has been parented, and it snaps to the parent's position.
+            // Then the target object has not been parented, and its position stays the same.
             Assert.AreEqual(parent.transform, target.transform.parent);
-            Assert.IsTrue(originalPosition == target.transform.position);
-            Assert.IsTrue((originalRotation == target.transform.rotation));
+            Assert.IsTrue((originalPosition - target.transform.position).sqrMagnitude < 0.001f);
+            Assert.IsTrue(Quaternion.Dot(originalRotation, target.transform.rotation) > 0.999f);
+        }
+
+        [UnityTest]
+        public IEnumerator ObjectSetToRootIfParentNotSet()
+        {
+            // Given a set parent behavior,
+            ProcessSceneObject target = SpawnTestObject("Target", Vector3.zero, Quaternion.identity, Vector3.one);
+            ProcessSceneObject parent = SpawnTestObject("Parent", Vector3.zero, Quaternion.identity, Vector3.one);
+            target.transform.SetParent(parent.transform);
+            IBehavior behavior = new SetParentBehavior(target, null);
+
+            // When the behavior completes,
+            behavior.LifeCycle.Activate();
+
+            while (behavior.LifeCycle.Stage != Stage.Active)
+            {
+                yield return null;
+                behavior.Update();
+            }
+
+            // Then the target object has been unparented.
+            Assert.AreEqual(null, target.transform.parent);
         }
     }
 }

--- a/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/SetParentBehaviorTests.cs.meta
+++ b/Source/Basic-Conditions-And-Behaviors/Tests/Behaviors/SetParentBehaviorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fec6961439a988a4b8e536229975be14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Core/Runtime/SceneObjects/SceneObjectReference.cs
+++ b/Source/Core/Runtime/SceneObjects/SceneObjectReference.cs
@@ -26,7 +26,6 @@ namespace VRBuilder.Core.SceneObjects
         {
             if (string.IsNullOrEmpty(UniqueName))
             {
-                Debug.LogWarningFormat("Scene object for name {0} not found", UniqueName);
                 return null;
             }
 


### PR DESCRIPTION
- Added "Set Parent" behavior, which parents a process scene object to another.
- Can parent to null object, in which case the object will be placed at the root.
- Can snap to the parent object's location and rotation.
- Should show a warning when the parented object will be deformed on parenting due to scale/rotation issues.